### PR TITLE
Add manifest JSON for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,7 @@
+{
+    "name": "FileSaver",
+    "version": "1.0.0",
+    "main": "./FileSaver.js",
+    "dependencies": {
+    }
+}


### PR DESCRIPTION
FileSaver isn't registered with Bower. To register it, a manifest JSON is required.

<a href="http://bower.io">Bower</a> is a package manager. After adding this JSON file, we can then register FileSaver like this:
`bower register <my-package-name> <git-endpoint>`
