### PR TITLE
Including FileSaver.js as a content script in Firefox for Android add-ons

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -14,7 +14,7 @@
 /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
 
 var saveAs = saveAs
-  || (navigator.msSaveOrOpenBlob && navigator.msSaveOrOpenBlob.bind(navigator))
+  || (typeof navigator !== 'undefined' && navigator.msSaveOrOpenBlob && navigator.msSaveOrOpenBlob.bind(navigator))
   || (function(view) {
 	"use strict";
 	var
@@ -116,9 +116,20 @@ var saveAs = saveAs
 			}
 			if (can_use_save_link) {
 				object_url = get_object_url(blob);
+				// FF for Android has a nasty garbage collection mechanism
+				// that turns all objects that are not pure javascript into 'deadObject'
+				// this means `doc` and `save_link` are unusable and need to be recreated
+				// `view` is usable though:
+				doc = view.document;
+				save_link = doc.createElementNS("http://www.w3.org/1999/xhtml", "a");
 				save_link.href = object_url;
 				save_link.download = name;
-				click(save_link);
+				var event = doc.createEvent("MouseEvents");
+				event.initMouseEvent(
+					"click", true, false, view, 0, 0, 0, 0, 0
+					, false, false, false, false, 0, null
+				);
+				save_link.dispatchEvent(event);
 				filesaver.readyState = filesaver.DONE;
 				dispatch_all();
 				return;
@@ -213,6 +224,9 @@ var saveAs = saveAs
 
 	view.addEventListener("unload", process_deletion_queue, false);
 	return saveAs;
-}(self));
+}(typeof self !== 'undefined' ? self : typeof this !== 'undefined' && this.content ? this.content : null));
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window
 
 if (typeof module !== 'undefined') module.exports = saveAs;


### PR DESCRIPTION
First off all, thanks for the lib, we use it in a cross-browser add-on we maintain.
Supporting FF mobile is a pain but I've finally got the time to debug issues with FileSaver.js

For starters, only `this` appears to be defined in that context and accessing any other object (like `self`, `navigator`) produces an exception. Consequently, Blob.js needs to be adapted accordingly.

Secondly, garbage collection is a pain here. Every DOM object seems to be recycled. This means references to `document` or `save_link` cannot be stored and relied upon. It enforced us to rewrite all the legacy code relying on XML to use JSON instead.

Last remark considers usage: you need to prefix `Blob` with `window.` in the actual event listeners.

I've added some comments in relevant places, I trust you'll figure out the best way to fix the situation, if at all.
