### PR TITLE
Browserify fix

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -224,7 +224,7 @@ var saveAs = saveAs
 
 	view.addEventListener("unload", process_deletion_queue, false);
 	return saveAs;
-}(this.self || this.window || this.content));
+}(this.self || this.window || this.content || window));
 // `self` is undefined in Firefox for Android content script context
 // while `this` is nsIContentFrameMessageManager
 // with an attribute `content` that corresponds to the window


### PR DESCRIPTION
When used with browserify, library produces next error:
`Uncaught TypeError: Cannot read property 'document' of undefined` on line 23, where we try to evaluate `view.document`.
This code change seems to help. 
Good enough or is there another fix for this? Not sure,  whether `this.window` had to be removed.
