### PR TITLE
saveAs.unload

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -228,6 +228,9 @@ var saveAs = saveAs
 		null;
 
 	view.addEventListener("unload", process_deletion_queue, false);
+	saveAs.unload = function() {
+		view.removeEventListener("unload", process_deletion_queue, false);
+	};
 	return saveAs;
 }(
 	   typeof self !== "undefined" && self


### PR DESCRIPTION
When all references to the library are gone it still leaks into the `view` via the added `unload` listener.
This is important in contexts that are somewhat persistent, e. g. in Firefox add-ons the `view` corresponds to the browser window which persists until the browser is closed.

The PR adds a `saveAs.unload` function that can be called during cleanup to remove the unload listener.
