### PR TITLE
allow installation with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "filesaver",
+  "name": "browser-filesaver",
   "version": "0.2.0",
   "description": "Cross-browser implementation of W3C saveAs API",
   "main": "FileSaver.js",


### PR DESCRIPTION
This continues the work of @caseygrun by adding a name for this package that has not yet been taken in the npm registry.

It would be really cool to get this published to `npm`!

The steps:
- land this pull request
- publish to npm

```
cd FileSaver.js
npm adduser
npm publish
```

then we can install using `npm install browser-filesaver` and use [browserify](http://browserify.org) to bundle this up with the rest of the project!
