### PR TITLE
Fix demo paths

### DIFF
--- a/demo/index.xhtml
+++ b/demo/index.xhtml
@@ -49,9 +49,9 @@
             <input type="submit" value="Save"/>
         </form>
     </section>
-    <script async="" src="https://raw.github.com/eligrey/Blob.js/master/Blob.min.js"/>
-    <script async="" src="https://raw.github.com/eligrey/canvas-toBlob.js/master/canvas-toBlob.js"/>
-    <script async="" src="https://raw.github.com/eligrey/FileSaver.js/master/FileSaver.js"/>
-    <script async="" src="https://raw.github.com/eligrey/FileSaver.js/master/demo/demo.js"/>
+    <script async="" src="https://cdn.rawgit.com/eligrey/Blob.js/master/Blob.js"/>
+    <script async="" src="https://cdn.rawgit.com/eligrey/canvas-toBlob.js/master/canvas-toBlob.js"/>
+    <script async="" src="https://cdn.rawgit.com/eligrey/FileSaver.js/master/FileSaver.js"/>
+    <script async="" src="https://cdn.rawgit.com/eligrey/FileSaver.js/master/demo/demo.js"/>
 </body>
 </html>


### PR DESCRIPTION
Blob.min.js does not exist, change to Blob.js

Replace raw.github.com w/ cdn.rawgit.com -- fixed "strict MIME type checking is enabled" as per: 

http://stackoverflow.com/questions/17341122/link-and-execute-external-javascript-file-hosted-on-github
