### PR TITLE
Add link to bower-compatible repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,8 @@ uglifyjs FileSaver.js --comments /@source/ > FileSaver.min.js
 ```
 
 Please make sure you build a production version before submitting a pull request.
+
+Bower Installation
+------------------
+
+Please see the [this repo](http://github.com/Teleborder/FileSaver.js) for a bower-compatible fork of FileSaver.js, available under the package name `file-saver.js`.


### PR DESCRIPTION
[This comment](https://github.com/eligrey/FileSaver.js/issues/104#issuecomment-64328197) indicates a willingness to include a link to a bower-compatible fork of FileSaver.js. I created the fork so that I could install it using bower (via rails-assets.org) and wanted to share.

Based on [previous statements](https://github.com/eligrey/FileSaver.js/pull/109#issuecomment-65692833) about converting the package to semver, I've used a versioning system that reflects this package actual version. The version  I uploaded is 1.20150304.1. Going forward I plan to change the minor version when new versions are released, with the date they are released as the minor version.

For example, if a new version were released today, I would update the bower package to version `1.20150322.0`.

I know that you [tweeted](https://twitter.com/sephr/status/542978804441169920) a recommendation to use the patch version as the date, but since most package managers treat patch bumps as easy upgrade paths, the minor version seemed more appropriate.