### PR TITLE
removing FileSaver.min.js from list of ignored files in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "file-saver.js",
+  "main": "FileSaver.js",
+  "version": "1.20150304.0",
+  "homepage": "https://github.com/Teleborder/FileSaver.js",
+  "authors": [
+    "Eli Grey (http://eligrey.com)"
+  ],
+  "description": "A saveAs() FileSaver implementation",
+  "keywords": [
+    "File",
+    "FileSaver",
+    "saveAs"
+  ],
+  "license": "LICENSE.md",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "demo",
+    "FileSaver.min.js"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "bower_components",
     "test",
     "tests",
-    "demo",
-    "FileSaver.min.js"
+    "demo"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "file-saver.js",
   "main": "FileSaver.js",
-  "version": "1.20150304.0",
+  "version": "1.20150304.1",
   "homepage": "https://github.com/Teleborder/FileSaver.js",
   "authors": [
     "Eli Grey (http://eligrey.com)"


### PR DESCRIPTION
My team needs to use the min version from your repo