### PR TITLE
Make NPM compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filesaver.js",
-  "version": "1.0.0",
+  "version": "1.0.20151003",
   "description": "FileSaver.js implements the HTML5 W3C saveAs() FileSaver interface in browsers that do not natively support it.",
   "main": "FileSaver.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "filesaver.js",
+  "version": "1.0.0",
+  "description": "FileSaver.js implements the HTML5 W3C saveAs() FileSaver interface in browsers that do not natively support it.",
+  "main": "FileSaver.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eligrey/FileSaver.js"
+  },
+  "keywords": [
+    "html5",
+    "canvas",
+    "file",
+    "blob",
+    "polyfill"
+  ],
+  "author": "Eli Grey <me@eligrey.com> (http://eligrey.com/)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/eligrey/FileSaver.js/issues"
+  },
+  "homepage": "https://github.com/eligrey/FileSaver.js"
+}


### PR DESCRIPTION
I added a "package.json" file with your information to make this package able to be included as a dependency via NPM. Now it can be added to the npm index, or simply included using:

    npm install eligrey/filesaver.js
