### PR TITLE
consistant AMD and commonJS

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -180,9 +180,9 @@ var saveAs = saveAs || (function(view) {
 // with an attribute `content` that corresponds to the window
 
 if (typeof module !== "undefined" && module.exports) {
-  module.exports.saveAs = saveAs;
+  module.exports = saveAs;
 } else if ((typeof define !== "undefined" && define !== null) && (define.amd !== null)) {
-  define("FileSaver.js", function() {
+  define([], function() {
     return saveAs;
   });
 }


### PR DESCRIPTION
currently when commonJs is used saveAs appears as:
```js
import {saveAs} from 'file-saver';
```
but when AMD is used, saveAs appears as:
```js
import saveAs from 'file-saver';
```