### PR TITLE
Fix exports for SystemJS

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -179,10 +179,10 @@ var saveAs = saveAs || (function(view) {
 // while `this` is nsIContentFrameMessageManager
 // with an attribute `content` that corresponds to the window
 
-if (typeof module !== "undefined" && module.exports) {
-  module.exports.saveAs = saveAs;
-} else if ((typeof define !== "undefined" && define !== null) && (define.amd !== null)) {
-  define("FileSaver.js", function() {
-    return saveAs;
-  });
+if (typeof define === 'function' && define.amd) {
+	define(function () {
+		return saveAs
+	})
+} else if (typeof module !== 'undefined' && module.exports) {
+	module.exports = saveAs
 }


### PR DESCRIPTION
Currently system.js fails to bundle this correctly because of the weird syntax used while defining it for amd/commonjs. This fixes that and makes the export consistent just as #299 and #229 fix.