### PR TITLE
Add saveAs to window

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -186,3 +186,6 @@ if (typeof module !== "undefined" && module.exports) {
     return saveAs;
   });
 }
+(function(w){
+	w.saveAs = saveAs;
+})(window);


### PR DESCRIPTION
This change ensures that the function saveAs is visible in window in some frameworks. Without this, filesaver cannot be used in places like salesforce lightning framework.