### PR TITLE
Revert interface change.

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -13,7 +13,7 @@
 
 /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/src/FileSaver.js */
 
-export default var saveAs = saveAs || (function(view) {
+export var saveAs = saveAs || (function(view) {
 	"use strict";
 	// IE <10 is explicitly unsupported
 	if (typeof view === "undefined" || typeof navigator !== "undefined" && /MSIE [1-9]\./.test(navigator.userAgent)) {


### PR DESCRIPTION
As mentioned in the comments on dfd5856, switching to using `default` is a breaking change and should be reserved for a major version increment. The syntax was invalid anyways, resulting in build failures. This is likely what caused the empty package in Bower.

Fixes #407, #409 (assuming someone with permissions follows through and builds/uploads).