### PR TITLE
Amended link to Apple's WebKit bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ press <kbd>⌘</kbd>+<kbd>S</kbd> to save the file after it is opened. Using the
 
 ### iOS
 
-saveAs must be run within a user interaction event such as onTouchDown or onClick; setTimeout will prevent saveAs from triggering. Due to restrictions in iOS saveAs opens in a new window instead of downloading, if you want this fixed please [tell Apple](https://bugs.webkit.org/show_bug.cgi?id=102914) how this bug is affecting you.
+saveAs must be run within a user interaction event such as onTouchDown or onClick; setTimeout will prevent saveAs from triggering. Due to restrictions in iOS saveAs opens in a new window instead of downloading, if you want this fixed please [tell Apple how this WebKit bug is affecting you](https://bugs.webkit.org/show_bug.cgi?id=167341).
 
 Syntax
 ------


### PR DESCRIPTION
WebKit bug №102914 is no longer the ticket referencing the "iOS can't do this" problem — that ticket has been closed since it was resolved on MacOS.

The appropriate WebKit bug ticket is [№167341: [iOS] Add support for the download attribute](https://bugs.webkit.org/show_bug.cgi?id=167341), so I have updated the link appropriately.

I have also expanded the link to include the following text, to make the point (that it's WebKit's bug, not FileSaver's) a little more obviously.