### PR TITLE
Replaced the non-breaking space at with space

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -46,7 +46,7 @@ function download (url, name, opts) {
   xhr.onload = function () {
     saveAs(xhr.response, name, opts)
   }
-  xhr.onerror = function () {
+  xhr.onerror = function () {
     console.error('could not download file')
   }
   xhr.send()


### PR DESCRIPTION
This is causing IE unable to recognize the "{" on line 49