### PR TITLE
Use more readable undefined check for local variable.

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -18,7 +18,7 @@ var _global = typeof window === 'object' && window.window === window
   : this
 
 function bom (blob, opts) {
-  if (typeof opts === 'undefined') opts = { autoBom: false }
+  if (opts === undefined) opts = { autoBom: false }
   else if (typeof opts !== 'object') {
     console.warn('Depricated: Expected third argument to be a object')
     opts = { autoBom: !opts }


### PR DESCRIPTION
typeof x === 'undefined' is the way to check if a variable is
undeclared or not. When you have a local variable, it is clearer to
check whether it is undefined. This also lets the JavaScript engine
catch a variable name typo in strict mode.