### PR TITLE
check if the URL object has a createObjectURL.

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -74,7 +74,7 @@ var saveAs = _global.saveAs || (
   // Use download attribute first if possible (#193 Lumia mobile)
   : 'download' in HTMLAnchorElement.prototype
   ? function saveAs (blob, name, opts) {
-    var URL = _global.URL || _global.webkitURL
+    var URL = (_global.URL && _global.URL.createObjectURL) ? _global.URL : _global.webkitURL
     var a = document.createElement('a')
     name = name || blob.name || 'download'
 


### PR DESCRIPTION
This fixes an issue in Firefox for pages on http. 
The error message produced is this: URL.createObjectURL is not a function

In Firefox on http, a window.Url from window.js is used (which does not have createObjectURL) instead of the window.URL; Using the webkit version fixes that problem.