### PR TITLE
Update FileSaver.js

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -47,7 +47,7 @@ function download (url, name, opts) {
 function corsEnabled (url) {
   var xhr = new XMLHttpRequest()
   // use sync to avoid popup blocker
-  xhr.open('HEAD', url, false)
+  xhr.open('GET', url, false)
   try {
     xhr.send()
   } catch (e) {}


### PR DESCRIPTION
Update HEAD request into GET when cors enabled. Because when using HEAD, will get 403 error from amazon. 