### PR TITLE
Fix problem that `isWebkit` be `true` on  Chrome

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -67,7 +67,8 @@ function click (node) {
 }
 
 // Detect WebKit inside a native macOS app
-var isWebKit = /AppleWebKit/.test(navigator.userAgent)
+var isWebKit = 
+    /AppleWebKit/.test(navigator.userAgent) && (!/Chrome/.test(navigator.userAgent))
 
 var saveAs = _global.saveAs || (
   // probably in some web worker


### PR DESCRIPTION
The user agent on Chrome also contains `AppleWebKit`。 Therefore the origin judgement condition will treat Chrome as "WebKit inside a native macOS app".

Here is the user agent string of Chrome 80 for Windows 10:

```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.106 Safari/537.36
```