### PR TITLE
Update FileSaver.js

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -31,7 +31,7 @@ function bom (blob, opts) {
   return blob
 }
 
-function download (url, name, opts) {
+function download (url, name, opts,popup) {
   var xhr = new XMLHttpRequest()
   xhr.open('GET', url)
   xhr.responseType = 'blob'
@@ -136,7 +136,7 @@ var saveAs = _global.saveAs || (
       popup.document.body.innerText = 'downloading...'
     }
 
-    if (typeof blob === 'string') return download(blob, name, opts)
+    if (typeof blob === 'string') return download(blob, name, opts,popup)
 
     var force = blob.type === 'application/octet-stream'
     var isSafari = /constructor/i.test(_global.HTMLElement) || _global.safari


### PR DESCRIPTION
This commite done for solvinig the problem of show saved file in current browser tab in safari ios .
the reason of this problem was that the new tab opened dont exist in runnin 'saveAs' function for second time in "onload" event that placed in 'download' function.
It probably solve this issues or may be some other....

- iOS (12) safari saveAS opens pdf in the same tab #531
- blob opens in current tab iOS Safari #581   