### PR TITLE
fix: the new popup not the download window

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -31,12 +31,12 @@ function bom (blob, opts) {
   return blob
 }
 
-function download (url, name, opts) {
+function download (url, name, opts, popup) {
   var xhr = new XMLHttpRequest()
   xhr.open('GET', url)
   xhr.responseType = 'blob'
   xhr.onload = function () {
-    saveAs(xhr.response, name, opts)
+    saveAs(xhr.response, name, opts, popup)
   }
   xhr.onerror = function () {
     console.error('could not download file')
@@ -136,7 +136,7 @@ var saveAs = _global.saveAs || (
       popup.document.body.innerText = 'downloading...'
     }
 
-    if (typeof blob === 'string') return download(blob, name, opts)
+    if (typeof blob === 'string') return download(blob, name, opts, popup)
 
     var force = blob.type === 'application/octet-stream'
     var isSafari = /constructor/i.test(_global.HTMLElement) || _global.safari


### PR DESCRIPTION
When using the safair 6.0+, the new popup is opened. But the download path not used in the new popup. Because the popup is not been passed.