### PR TITLE
Console log an error when saveAs is called from a web worker

### DIFF
--- a/src/FileSaver.js
+++ b/src/FileSaver.js
@@ -74,7 +74,7 @@ var isMacOSWebView = _global.navigator && /Macintosh/.test(navigator.userAgent) 
 var saveAs = _global.saveAs || (
   // probably in some web worker
   (typeof window !== 'object' || window !== _global)
-    ? function saveAs () { /* noop */ }
+    ? function saveAs () { /* noop */ console.error('WARNING: FileSaver.saveAs() will not work if called in a web worker. Call it from the main thread instead.') }
 
   // Use download attribute first if possible (#193 Lumia mobile) unless this is a macOS WebView
   : ('download' in HTMLAnchorElement.prototype && !isMacOSWebView)


### PR DESCRIPTION
Currently if you try to run saveAs from a web worker, it fails silently. Instead we should send an error to the console to communicate that saveAs can only be called from the main thread.

Fixes https://github.com/eligrey/FileSaver.js/issues/778.